### PR TITLE
Eliminate cross-project configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 8
           - 11
           - 17
           - 19
@@ -57,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
           cache: 'gradle'
 
       - name: Build
@@ -87,7 +86,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: 11
           cache: 'gradle'
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   jvm:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     strategy:
       fail-fast: false
@@ -41,6 +42,7 @@ jobs:
 
   js:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     strategy:
       fail-fast: false
@@ -69,6 +71,7 @@ jobs:
 
   native:
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ This project is the template for any project using Kotlin Multiplatform.
 
 - https://github.com/square/okio
 - https://github.com/android/nowinandroid
-
+- https://developer.squareup.com/blog/stampeding-elephants/
+    - https://developer.squareup.com/blog/herding-elephants/

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -4,21 +4,29 @@ import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.li
 import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.mingwTargets
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.configureOrCreateNativePlatforms
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.createSourceSet
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.js.KotlinJsTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.nio.charset.StandardCharsets
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.dokka")
 
+    id("io.github.kotlin.multiplaform.template.gradle.project.base.dokka")
     id("io.github.kotlin.multiplaform.template.gradle.project.base.spotless.java")
 }
 
 group = "io.github.kotlin.multiplaform.template.application"
 version = "0.1.0"
 
+repositories {
+    mavenCentral()
+    google()
+}
 
 /*
  * Here's the main hierarchy of variants. Any `expect` functions in one level of the tree are
@@ -139,5 +147,27 @@ kotlin {
                 createSourceSet("appleTest", parent = nativeTest, children = appleTargets)
             }
         }
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        @Suppress("SuspiciousCollectionReassignment")
+        freeCompilerArgs += "-Xjvm-default=all"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = StandardCharsets.UTF_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType<Test> {
+    testLogging {
+        events(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = false
     }
 }

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -152,7 +152,7 @@ kotlin {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
         @Suppress("SuspiciousCollectionReassignment")
         freeCompilerArgs += "-Xjvm-default=all"
     }
@@ -160,8 +160,8 @@ tasks.withType<KotlinCompile>().configureEach {
 
 tasks.withType<JavaCompile> {
     options.encoding = StandardCharsets.UTF_8.toString()
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
 }
 
 tasks.withType<Test> {

--- a/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
+++ b/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
@@ -7,6 +7,6 @@ fun main() {
         """
             |Application:
             |	${Greeting().hello()}
-        """.trimMargin()
+        """.trimMargin(),
     )
 }

--- a/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
+++ b/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
@@ -6,7 +6,7 @@ fun main() {
     println(
         """
             |Application:
-            |\t${Greeting().hello()}
-        """.trimMargin(),
+            |	${Greeting().hello()}
+        """.trimMargin()
     )
 }

--- a/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
+++ b/application/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/application/Main.kt
@@ -7,6 +7,6 @@ fun main() {
         """
             |Application:
             |\t${Greeting().hello()}
-        """.trimMargin()
+        """.trimMargin(),
     )
 }

--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -10,16 +10,11 @@ plugins {
 
 group = "io.github.kotlin.multiplaform.template.gradle"
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_19
-    targetCompatibility = JavaVersion.VERSION_19
-}
-
 dependencies {
-    add("compileOnly", libs.android.gradlePlugin)
-    add("compileOnly", libs.dokka.gradlePlugin)
-    add("compileOnly", libs.kotlin.gradlePlugin)
-    add("compileOnly", libs.spotless.gradlePlugin)
+    implementation(libs.android.gradlePlugin)
+    implementation(libs.dokka.gradlePlugin)
+    implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.spotless.gradlePlugin)
 }
 
 gradlePlugin {

--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets
 
 plugins {
     `kotlin-dsl`
+    `java-gradle-plugin`
 }
 
 group = "io.github.kotlin.multiplaform.template.gradle"
@@ -15,9 +16,10 @@ java {
 }
 
 dependencies {
-    implementation(libs.android.gradlePlugin)
-    implementation(libs.kotlin.gradlePlugin)
-    implementation(libs.spotless.gradlePlugin)
+    add("compileOnly", libs.android.gradlePlugin)
+    add("compileOnly", libs.dokka.gradlePlugin)
+    add("compileOnly", libs.kotlin.gradlePlugin)
+    add("compileOnly", libs.spotless.gradlePlugin)
 }
 
 gradlePlugin {
@@ -30,6 +32,14 @@ gradlePlugin {
         //     id = "io.github.kotlin.multiplaform.template.gradle.project.application.android"
         //     implementationClass = "io.github.kotlin.multiplaform.template.gradle.project.application.AndroidApplicationPlugin"
         // }
+
+        // Dokka
+        register("dokka") {
+            id = "io.github.kotlin.multiplaform.template.gradle.project.base.dokka"
+            implementationClass = "io.github.kotlin.multiplaform.template.gradle.project.base.DokkaPlugin"
+        }
+
+        // Spotless
         register("javaSpotless") {
             id = "io.github.kotlin.multiplaform.template.gradle.project.base.spotless.java"
             implementationClass = "io.github.kotlin.multiplaform.template.gradle.project.base.SpotlessJavaPlugin"
@@ -38,33 +48,5 @@ gradlePlugin {
             id = "io.github.kotlin.multiplaform.template.gradle.project.base.spotless.android"
             implementationClass = "io.github.kotlin.multiplaform.template.gradle.project.base.SpotlessAndroidPlugin"
         }
-    }
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
-        freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all"
-        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
-
-    }
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    options.encoding = StandardCharsets.UTF_8.toString()
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events(
-            TestLogEvent.STARTED,
-            TestLogEvent.PASSED,
-            TestLogEvent.SKIPPED,
-            TestLogEvent.FAILED
-        )
-        exceptionFormat = TestExceptionFormat.FULL
-        showStandardStreams = false
     }
 }

--- a/build-logic/plugins/src/main/kotlin/io/github/kotlin/multiplaform/template/gradle/project/base/DokkaPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/io/github/kotlin/multiplaform/template/gradle/project/base/DokkaPlugin.kt
@@ -1,0 +1,47 @@
+package io.github.kotlin.multiplaform.template.gradle.project.base
+
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.dokka.gradle.DokkaTask
+
+class DokkaPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            pluginManager.apply("org.jetbrains.dokka")
+            tasks.withType(DokkaTask::class).configureEach {
+                dokkaSourceSets.configureEach {
+                    // includes.from("README.md")
+                    // samples.from("samples/**.kt")
+
+                    reportUndocumented.set(true)
+                    skipDeprecated.set(true)
+                    jdkVersion.set(JavaVersion.VERSION_1_8.toString().toInt())
+                    perPackageOption {
+                        matchingRegex.set("""io\.github\.kotlin\.multiplaform\.template\..*\.internal.*""")
+                        suppress.set(true)
+                    }
+                }
+
+                if (name == "dokkaHtml") {
+                    outputDirectory.set(file("${rootDir}/docs/$version/${project.name}"))
+                    pluginsMapConfiguration.set(
+                        mapOf(
+                            "org.jetbrains.dokka.base.DokkaBase" to """
+                            |{
+                            |  "customStyleSheets": [
+                            |    "${rootDir.toString().replace('\\', '/')}/docs/css/dokka-logo.css"
+                            |  ],
+                            |  "customAssets" : [
+                            |    "${rootDir.toString().replace('\\', '/')}/docs/images/ic_project.svg"
+                            |  ]
+                            |}
+                            """.trimMargin()
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/build-logic/plugins/src/main/kotlin/io/github/kotlin/multiplaform/template/gradle/project/base/DokkaPlugin.kt
+++ b/build-logic/plugins/src/main/kotlin/io/github/kotlin/multiplaform/template/gradle/project/base/DokkaPlugin.kt
@@ -17,7 +17,7 @@ class DokkaPlugin : Plugin<Project> {
 
                     reportUndocumented.set(true)
                     skipDeprecated.set(true)
-                    jdkVersion.set(JavaVersion.VERSION_1_8.toString().toInt())
+                    jdkVersion.set(JavaVersion.VERSION_11.toString().toInt())
                     perPackageOption {
                         matchingRegex.set("""io\.github\.kotlin\.multiplaform\.template\..*\.internal.*""")
                         suppress.set(true)
@@ -37,7 +37,7 @@ class DokkaPlugin : Plugin<Project> {
                             |    "${rootDir.toString().replace('\\', '/')}/docs/images/ic_project.svg"
                             |  ]
                             |}
-                            """.trimMargin()
+                            """.trimMargin(),
                         )
                     )
                 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,7 @@
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
     repositories {
         google()
@@ -12,5 +14,7 @@ dependencyResolutionManagement {
         }
     }
 }
+
+rootProject.name = "build-logic"
 
 include(":plugins")

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,4 +1,3 @@
-
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
 @Suppress("UnstableApiUsage")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,9 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import nl.littlerobots.vcu.plugin.versionCatalogUpdate
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.nio.charset.StandardCharsets
 
 plugins {
     `version-catalog`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,13 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import nl.littlerobots.vcu.plugin.versionCatalogUpdate
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
-import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
-import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
-import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
-import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.nio.charset.StandardCharsets
 
 plugins {
     `version-catalog`
+}
+
+repositories {
+    mavenCentral()
+    google()
 }
 
 buildscript {
@@ -50,69 +47,5 @@ tasks.withType<DependencyUpdatesTask> {
 versionCatalogUpdate {
     keep {
         version
-    }
-}
-
-allprojects {
-    repositories {
-        mavenCentral()
-        google()
-    }
-
-    tasks.withType(DokkaTask::class).configureEach {
-        dokkaSourceSets.configureEach {
-            // includes.from("README.md")
-            // samples.from("samples/**.kt")
-
-            reportUndocumented.set(true)
-            skipDeprecated.set(true)
-            jdkVersion.set(11)
-            perPackageOption {
-                matchingRegex.set("io\\.github\\.kotlin\\.multiplaform\\.template\\..*\\.internal.*")
-                suppress.set(true)
-            }
-        }
-
-        if (name == "dokkaHtml") {
-            outputDirectory.set(file("${rootDir}/docs/$version/${project.name}"))
-            pluginsMapConfiguration.set(
-                mapOf(
-                    "org.jetbrains.dokka.base.DokkaBase" to """
-                    |{
-                    |  "customStyleSheets": [
-                    |    "${rootDir.toString().replace('\\', '/')}/docs/css/dokka-logo.css"
-                    |  ],
-                    |  "customAssets" : [
-                    |    "${rootDir.toString().replace('\\', '/')}/docs/images/ic_project.svg"
-                    |  ]
-                    |}
-                """.trimMargin()
-                )
-            )
-        }
-    }
-}
-
-subprojects {
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
-            @Suppress("SuspiciousCollectionReassignment")
-            freeCompilerArgs += "-Xjvm-default=all"
-        }
-    }
-
-    tasks.withType<JavaCompile> {
-        options.encoding = StandardCharsets.UTF_8.toString()
-        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-        targetCompatibility = JavaVersion.VERSION_1_8.toString()
-    }
-
-    tasks.withType<Test> {
-        testLogging {
-            events(STARTED, PASSED, SKIPPED, FAILED)
-            exceptionFormat = TestExceptionFormat.FULL
-            showStandardStreams = false
-        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,15 @@
 [versions]
-androidGradlePlugin = "7.3.1"
-kotlin = "1.7.22"
+androidGradlePlugin = "7.4.1"
+kotlin = "1.8.10"
 # @keep this version, it is not used in a dependency declaration but it used for spotless configuration
-ktlint = "0.46.1"
-spotless = "6.12.0"
+ktlint = "0.48.2"
+spotless = "6.14.1"
 
 [libraries]
 android-gradlePlugin = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
-dependencies-versions-gradlePlugin = "com.github.ben-manes:gradle-versions-plugin:0.44.0"
+dependencies-versions-gradlePlugin = "com.github.ben-manes:gradle-versions-plugin:0.45.0"
 dependencies-versions-update-gradlePlugin = "nl.littlerobots.vcu:plugin:0.7.0"
 dokka-gradlePlugin = "org.jetbrains.dokka:dokka-gradle-plugin:1.7.20"
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
-kotlinx-datetime = "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
 spotless-gradlePlugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }

--- a/library/lib-a/build.gradle.kts
+++ b/library/lib-a/build.gradle.kts
@@ -4,18 +4,26 @@ import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.li
 import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.mingwTargets
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.configureOrCreateNativePlatforms
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.createSourceSet
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.nio.charset.StandardCharsets
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.dokka")
 
+    id("io.github.kotlin.multiplaform.template.gradle.project.base.dokka")
     id("io.github.kotlin.multiplaform.template.gradle.project.base.spotless.java")
 }
 
 group = "io.github.kotlin.multiplaform.template.lib.a"
 version = "0.1.0"
 
+repositories {
+    mavenCentral()
+    google()
+}
 
 /*
  * Here's the main hierarchy of variants. Any `expect` functions in one level of the tree are
@@ -113,5 +121,27 @@ kotlin {
                 createSourceSet("appleTest", parent = nativeTest, children = appleTargets)
             }
         }
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        @Suppress("SuspiciousCollectionReassignment")
+        freeCompilerArgs += "-Xjvm-default=all"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = StandardCharsets.UTF_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType<Test> {
+    testLogging {
+        events(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = false
     }
 }

--- a/library/lib-a/build.gradle.kts
+++ b/library/lib-a/build.gradle.kts
@@ -126,7 +126,7 @@ kotlin {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
         @Suppress("SuspiciousCollectionReassignment")
         freeCompilerArgs += "-Xjvm-default=all"
     }
@@ -134,8 +134,8 @@ tasks.withType<KotlinCompile>().configureEach {
 
 tasks.withType<JavaCompile> {
     options.encoding = StandardCharsets.UTF_8.toString()
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
 }
 
 tasks.withType<Test> {

--- a/sample/example-a/build.gradle.kts
+++ b/sample/example-a/build.gradle.kts
@@ -4,21 +4,29 @@ import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.li
 import io.github.kotlin.multiplaform.template.gradle.project.utils.SystemInfo.mingwTargets
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.configureOrCreateNativePlatforms
 import io.github.kotlin.multiplaform.template.gradle.project.utils.extenstion.createSourceSet
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.js.KotlinJsTarget
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.nio.charset.StandardCharsets
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.dokka")
 
+    id("io.github.kotlin.multiplaform.template.gradle.project.base.dokka")
     id("io.github.kotlin.multiplaform.template.gradle.project.base.spotless.java")
 }
 
 group = "io.github.kotlin.multiplaform.template.example.a"
 version = "0.1.0"
 
+repositories {
+    mavenCentral()
+    google()
+}
 
 /*
  * Here's the main hierarchy of variants. Any `expect` functions in one level of the tree are
@@ -142,5 +150,27 @@ kotlin {
                 createSourceSet("appleTest", parent = nativeTest, children = appleTargets)
             }
         }
+    }
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        @Suppress("SuspiciousCollectionReassignment")
+        freeCompilerArgs += "-Xjvm-default=all"
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.encoding = StandardCharsets.UTF_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+}
+
+tasks.withType<Test> {
+    testLogging {
+        events(TestLogEvent.STARTED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
+        exceptionFormat = TestExceptionFormat.FULL
+        showStandardStreams = false
     }
 }

--- a/sample/example-a/build.gradle.kts
+++ b/sample/example-a/build.gradle.kts
@@ -155,7 +155,7 @@ kotlin {
 
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8.toString()
+        jvmTarget = JavaVersion.VERSION_11.toString()
         @Suppress("SuspiciousCollectionReassignment")
         freeCompilerArgs += "-Xjvm-default=all"
     }
@@ -163,8 +163,8 @@ tasks.withType<KotlinCompile>().configureEach {
 
 tasks.withType<JavaCompile> {
     options.encoding = StandardCharsets.UTF_8.toString()
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    sourceCompatibility = JavaVersion.VERSION_11.toString()
+    targetCompatibility = JavaVersion.VERSION_11.toString()
 }
 
 tasks.withType<Test> {

--- a/sample/example-a/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/example/a/Main.kt
+++ b/sample/example-a/src/commonMain/kotlin/io/github/kotlin/multiplaform/template/example/a/Main.kt
@@ -7,6 +7,6 @@ fun main() {
         """
             |Sample A:
             |\t${Greeting().hello()}
-        """.trimMargin()
+        """.trimMargin(),
     )
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,10 +2,6 @@ import Settings_gradle.ModuleType.APP
 import Settings_gradle.ModuleType.LIBRARY
 import Settings_gradle.ModuleType.SAMPLE
 
-rootProject.name = "kotlin-multiplatform-project-template"
-
-rootProject.buildFileName = "build.gradle.kts"
-
 enum class ModuleType(private val parentDirName: String) {
     /**
      * Binary project type.
@@ -88,6 +84,9 @@ pluginManagement {
 //         gradlePluginPortal()
 //     }
 // }
+
+rootProject.name = "kotlin-multiplatform-project-template"
+rootProject.buildFileName = "build.gradle.kts"
 
 // App
 includeProject("application", APP)


### PR DESCRIPTION
Eliminate cross-project configuration (think: `allprojects` and `subprojects`) so that every module (or "project", to use Gradle terminology) could be configured independently from every other. 

This should improve the configuration phase of the build, since those APIs defeat configuration on demand; and it also sets up to be compatible with a new experimental Gradle feature known as project isolation, which holds the promise of making slow Android Studio syncs a thing of the past.